### PR TITLE
Add URL param sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - There was an issue when changing radio selection, which is now fixed.
 
 [1.0.19]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.19
+
+## [1.0.20] - YYYY-MM-DD
+
+### Added
+
+- Filters now sync with URL parameters. Changing a filter updates `window.location.search`, and existing query parameters are applied on load.
+
+[1.0.20]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.20

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ A no-code solution that seamlessly integrates filtering and pagination into your
 - **Debounced Filter Updates** – Prevent unnecessary requests for a smoother experience.
 - **State Management Built-in** – Filters stay in sync without extra setup.
 - **Seamless Infinite Scroll** – Load more content automatically as users scroll.
+- **URL Sync** – Filter selections are stored in the page URL and restored on reload.
+
+## URL Sync Example
+
+When a user selects filters, the choices appear in the page URL and will be applied on reload.
+
+Example:
+`https://example.com/?category=Shoes&color=Red`
   <br><br>
   <br><br>
   <br><br>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -57,6 +57,17 @@ global.window = {
     exists: jest.fn(),
     removeByValue: jest.fn(),
   },
+  location: {
+    search: '',
+    pathname: '/',
+    hash: '',
+  },
+  history: {
+    replaceState: jest.fn((_, __, url) => {
+      const parsed = new URL(url, 'http://localhost');
+      global.window.location.search = parsed.search;
+    }),
+  },
 };
 
 // Mock MutationObserver

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wized-filter-and-pagination",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Wized filter and pagination functionality",
   "main": "dist/index.min.js",
   "module": "dist/index.esm.js",

--- a/src/__tests__/unit/URLSync.test.js
+++ b/src/__tests__/unit/URLSync.test.js
@@ -1,0 +1,38 @@
+/* global describe, test, expect, beforeEach */
+import { setParam, applyParamsToWized } from '../../utils/url-sync';
+import Wized from '../../__mocks__/wized';
+import FilterSearchManager from '../../filters/filter-search';
+
+describe('URL Sync', () => {
+  beforeEach(() => {
+    window.location.search = '';
+    window.history.replaceState.mockClear();
+    Wized.data.v = {};
+  });
+
+  test('changing search filter updates location search', async () => {
+    const input = {
+      value: 'shoes',
+      getAttribute: (attr) => {
+        if (attr === 'w-filter-search-variable') return 'searchVar';
+        if (attr === 'w-filter-pagination-current-variable') return 'page';
+        if (attr === 'w-filter-request') return 'req';
+        if (attr === 'wized') return 'search';
+        return null;
+      },
+      addEventListener: jest.fn(),
+    };
+
+    const manager = new FilterSearchManager(Wized);
+    manager.setupSearch(input);
+
+    await manager.updateWizedVariable(input, 'searchVar', 'page', 'req');
+    expect(window.location.search).toBe('?search=shoes');
+  });
+
+  test('applyParamsToWized populates variables from URL', () => {
+    window.location.search = '?search=boots';
+    applyParamsToWized(Wized, { search: 'searchVar' });
+    expect(Wized.data.v.searchVar).toBe('boots');
+  });
+});

--- a/src/filters/filter-radio.js
+++ b/src/filters/filter-radio.js
@@ -1,6 +1,7 @@
 /**
  * FilterRadioManager: Main class responsible for managing radio-based filtering functionality
- */
+*/
+import { setParam } from '../utils/url-sync.js';
 export default class FilterRadioManager {
   constructor(Wized) {
     console.log('[FilterRadioManager] Initializing...');
@@ -13,6 +14,8 @@ export default class FilterRadioManager {
       hasChipsSupport: false, // Track if chips functionality is available
       isProcessing: false, // Flag to prevent recursive updates
     };
+
+    this.paramMap = {};
 
     // Bind methods
     this.setupFilterMonitoring = this.setupFilterMonitoring.bind(this);
@@ -168,6 +171,13 @@ export default class FilterRadioManager {
       });
 
       this.Wized.data.v[variableName] = value;
+
+      const paramName = Object.keys(this.paramMap).find(
+        (key) => this.paramMap[key] === variableName
+      );
+      if (paramName) {
+        setParam(paramName, value);
+      }
 
       if (paginationVariable) {
         console.log('Resetting pagination to 1');
@@ -378,6 +388,19 @@ export default class FilterRadioManager {
         this.Wized.data.v[variableName] = '';
       }
 
+      if (wizedName) {
+        this.paramMap[wizedName] = variableName;
+      }
+
+      const currentValue = this.Wized.data.v[variableName];
+      if (currentValue) {
+        elements.forEach((radio) => {
+          const label = this.getRadioLabel(radio);
+          const shouldCheck = label === currentValue;
+          this.updateRadioVisualState(radio, shouldCheck);
+        });
+      }
+
       this.setupResetButton(group);
 
       elements.forEach((radio) => {
@@ -459,6 +482,12 @@ export default class FilterRadioManager {
 
       try {
         this.Wized.data.v[variableName] = '';
+        const paramName = Object.keys(this.paramMap).find(
+          (key) => this.paramMap[key] === variableName
+        );
+        if (paramName) {
+          setParam(paramName, '');
+        }
         console.log('[FilterRadioManager] Successfully reset Wized variable:', variableName);
       } catch (error) {
         console.error('[FilterRadioManager] Error resetting Wized variable:', variableName, error);

--- a/src/filters/filter-search.js
+++ b/src/filters/filter-search.js
@@ -9,6 +9,7 @@
  * 3. Event Handling: Manages input events with debouncing
  * 4. Wized Integration: Coordinates with Wized for data and requests
  */
+import { setParam } from '../utils/url-sync.js';
 class FilterSearchManager {
   constructor(Wized) {
     this.Wized = Wized;
@@ -19,6 +20,8 @@ class FilterSearchManager {
       debounceTimers: new Map(), // Tracks debounce timers for each search input
       initialized: false,
     };
+
+    this.paramMap = {};
 
     // Configuration
     this.config = {
@@ -95,6 +98,12 @@ class FilterSearchManager {
 
     // Update Wized variable
     this.Wized.data.v[variableName] = value;
+    const paramName = Object.keys(this.paramMap).find(
+      (key) => this.paramMap[key] === variableName
+    );
+    if (paramName) {
+      setParam(paramName, value);
+    }
     console.log(`Updated search variable ${variableName} to:`, value);
 
     // Reset pagination if needed
@@ -138,9 +147,18 @@ class FilterSearchManager {
     const paginationVariable = searchInput.getAttribute('w-filter-pagination-current-variable');
     const filterRequest = searchInput.getAttribute('w-filter-request');
 
+    const paramName = searchInput.getAttribute('wized');
+    if (paramName) {
+      this.paramMap[paramName] = variableName;
+    }
+
     // Initialize Wized variable if needed
     if (typeof this.Wized.data.v[variableName] === 'undefined') {
       this.Wized.data.v[variableName] = '';
+    }
+
+    if (this.Wized.data.v[variableName]) {
+      searchInput.value = this.Wized.data.v[variableName];
     }
 
     // Add input handler with debouncing

--- a/src/filters/filter-select-range.js
+++ b/src/filters/filter-select-range.js
@@ -8,6 +8,7 @@
  * 4. Wized Integration: Coordinates with Wized for data and requests
  * 5. Dynamic Options: Manages dynamic option updates
  */
+import { setParam } from '../utils/url-sync.js';
 export default class FilterSelectRangeManager {
   constructor(Wized) {
     this.Wized = Wized;
@@ -19,6 +20,8 @@ export default class FilterSelectRangeManager {
       processingChange: false, // Prevent multiple simultaneous changes
       dynamicRanges: new Map(), // Track ranges with dynamic options
     };
+
+    this.paramMap = {};
 
     // Bind methods
     this.setupFilterMonitoring = this.setupFilterMonitoring.bind(this);
@@ -306,6 +309,19 @@ export default class FilterSelectRangeManager {
     this.Wized.data.v[fromVariable] = fromValue;
     this.Wized.data.v[toVariable] = toValue;
 
+    const fromParam = Object.keys(this.paramMap).find(
+      (key) => this.paramMap[key] === fromVariable
+    );
+    if (fromParam) {
+      setParam(fromParam, fromValue);
+    }
+    const toParam = Object.keys(this.paramMap).find(
+      (key) => this.paramMap[key] === toVariable
+    );
+    if (toParam) {
+      setParam(toParam, toValue);
+    }
+
     if (isReset || fromValue || toValue || (!forceEmpty && (!fromValue || !toValue))) {
       if (paginationVariable) {
         this.Wized.data.v[paginationVariable] = 1;
@@ -418,12 +434,28 @@ export default class FilterSelectRangeManager {
     const filterRequest = fromSelect.getAttribute('w-filter-request');
     const requestName = fromSelect.getAttribute('w-filter-select-range-request');
 
+    const fromParam = fromSelect.getAttribute('wized');
+    if (fromParam) {
+      this.paramMap[fromParam] = fromVariable;
+    }
+    const toParam = toSelect.getAttribute('wized');
+    if (toParam) {
+      this.paramMap[toParam] = toVariable;
+    }
+
     // Initialize Wized variables if needed
     if (typeof this.Wized.data.v[fromVariable] === 'undefined') {
       this.Wized.data.v[fromVariable] = '';
     }
     if (typeof this.Wized.data.v[toVariable] === 'undefined') {
       this.Wized.data.v[toVariable] = '';
+    }
+
+    if (this.Wized.data.v[fromVariable]) {
+      fromSelect.value = this.Wized.data.v[fromVariable];
+    }
+    if (this.Wized.data.v[toVariable]) {
+      toSelect.value = this.Wized.data.v[toVariable];
     }
 
     this.setupResetButton(
@@ -562,6 +594,19 @@ export default class FilterSelectRangeManager {
       const toVariable = select.getAttribute('w-filter-select-range-to-variable');
       if (fromVariable) this.Wized.data.v[fromVariable] = '';
       if (toVariable) this.Wized.data.v[toVariable] = '';
+
+      if (fromVariable) {
+        const param = Object.keys(this.paramMap).find(
+          (k) => this.paramMap[k] === fromVariable
+        );
+        if (param) setParam(param, '');
+      }
+      if (toVariable) {
+        const param = Object.keys(this.paramMap).find(
+          (k) => this.paramMap[k] === toVariable
+        );
+        if (param) setParam(param, '');
+      }
     });
   }
 }

--- a/src/filters/filter-select.js
+++ b/src/filters/filter-select.js
@@ -9,6 +9,7 @@
  * 5. Chips Integration: Coordinates with FilterChipsManager for visual feedback
  * 6. Dynamic Options: Manages dynamic option updates
  */
+import { setParam } from '../utils/url-sync.js';
 export default class FilterSelectManager {
   constructor(Wized) {
     this.Wized = Wized;
@@ -20,6 +21,8 @@ export default class FilterSelectManager {
       processingChange: false, // Prevent multiple simultaneous changes
       dynamicSelects: new Map(), // Track selects with dynamic options
     };
+
+    this.paramMap = {};
 
     // Bind methods
     this.setupFilterMonitoring = this.setupFilterMonitoring.bind(this);
@@ -181,6 +184,13 @@ export default class FilterSelectManager {
     // Update Wized variable
     this.Wized.data.v[variableName] = value;
 
+    const paramName = Object.keys(this.paramMap).find(
+      (key) => this.paramMap[key] === variableName
+    );
+    if (paramName) {
+      setParam(paramName, value);
+    }
+
     // Reset pagination if needed
     if (paginationVariable) {
       this.Wized.data.v[paginationVariable] = 1;
@@ -267,9 +277,18 @@ export default class FilterSelectManager {
     const category = select.getAttribute('w-filter-select-category');
     const isDynamic = !!requestName;
 
+    const paramName = select.getAttribute('wized');
+    if (paramName) {
+      this.paramMap[paramName] = variableName;
+    }
+
     // Initialize Wized variable if needed
     if (typeof this.Wized.data.v[variableName] === 'undefined') {
       this.Wized.data.v[variableName] = '';
+    }
+
+    if (this.Wized.data.v[variableName]) {
+      select.value = this.Wized.data.v[variableName];
     }
 
     // Setup reset functionality
@@ -359,6 +378,12 @@ export default class FilterSelectManager {
       const variableName = select.getAttribute('w-filter-select-variable');
       select.selectedIndex = 0;
       this.Wized.data.v[variableName] = '';
+      const paramName = Object.keys(this.paramMap).find(
+        (key) => this.paramMap[key] === variableName
+      );
+      if (paramName) {
+        setParam(paramName, '');
+      }
     }
   }
 }

--- a/src/filters/filter-sort.js
+++ b/src/filters/filter-sort.js
@@ -7,6 +7,7 @@
  * 3. Event Handling: Manages change events and request completions
  * 4. Wized Integration: Coordinates with Wized for data and requests
  */
+import { setParam } from '../utils/url-sync.js';
 export default class FilterSortManager {
   constructor(Wized) {
     // console.log("FilterSortManager: Initializing...");
@@ -19,6 +20,8 @@ export default class FilterSortManager {
       processingChange: false, // Prevent multiple simultaneous changes
       dynamicSorts: new Map(), // Track selects with dynamic options
     };
+
+    this.paramMap = {};
 
     // Bind methods
     this.setupFilterMonitoring = this.setupFilterMonitoring.bind(this);
@@ -149,6 +152,13 @@ export default class FilterSortManager {
 
     // Update Wized variable
     this.Wized.data.v[variableName] = value;
+
+    const paramName = Object.keys(this.paramMap).find(
+      (key) => this.paramMap[key] === variableName
+    );
+    if (paramName) {
+      setParam(paramName, select.value || '');
+    }
     // console.log("FilterSortManager: Updated Wized variable:", variableName, "with value:", value);
 
     // Reset pagination if needed
@@ -227,6 +237,11 @@ export default class FilterSortManager {
     const requestName = select.getAttribute('w-filter-sort-request');
     const isDynamic = !!requestName;
 
+    const paramName = select.getAttribute('wized');
+    if (paramName) {
+      this.paramMap[paramName] = variableName;
+    }
+
     // Find the options wrapper with matching category
     const optionsWrapper = document.querySelector(
       `[w-filter-sort-category="${category}"][w-filter-sort-option="wrapper"]`
@@ -268,6 +283,10 @@ export default class FilterSortManager {
     // Initialize Wized variable if needed
     if (typeof this.Wized.data.v[variableName] === 'undefined') {
       this.Wized.data.v[variableName] = [];
+    }
+
+    if (Array.isArray(this.Wized.data.v[variableName]) && this.Wized.data.v[variableName].length > 0) {
+      select.value = JSON.stringify(this.Wized.data.v[variableName][0]);
     }
 
     // Setup dynamic functionality if needed
@@ -462,6 +481,12 @@ export default class FilterSortManager {
 
       sortSelect.selectedIndex = 0;
       this.Wized.data.v[variableName] = [];
+      const paramName = Object.keys(this.paramMap).find(
+        (key) => this.paramMap[key] === variableName
+      );
+      if (paramName) {
+        setParam(paramName, '');
+      }
       // console.log("FilterSortManager: Reset sort select:", variableName);
       return;
     }
@@ -494,6 +519,12 @@ export default class FilterSortManager {
 
       select.selectedIndex = 0;
       this.Wized.data.v[variableName] = [];
+      const paramName = Object.keys(this.paramMap).find(
+        (key) => this.paramMap[key] === variableName
+      );
+      if (paramName) {
+        setParam(paramName, '');
+      }
       // console.log("FilterSortManager: Reset complete for:", variableName);
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import FilterSortManager from './filters/filter-sort.js';
 import FilterPaginationManager from './filters/filter-pagination.js';
 import FilterResetManager from './filters/filter-reset.js';
 import FilterSearchManager from './filters/filter-search.js';
+import { applyParamsToWized } from './utils/url-sync.js';
 
 // Export all components
 export { FilterCheckboxManager };
@@ -23,6 +24,38 @@ export { FilterSearchManager };
 if (typeof window !== 'undefined') {
   window.Wized = window.Wized || [];
   window.Wized.push((Wized) => {
+    const buildMapping = () => {
+      const mapping = {};
+      document.querySelectorAll('[wized][w-filter-checkbox-variable]').forEach((el) => {
+        mapping[el.getAttribute('wized')] = el.getAttribute('w-filter-checkbox-variable');
+      });
+      document.querySelectorAll('[wized][w-filter-radio-variable]').forEach((el) => {
+        mapping[el.getAttribute('wized')] = el.getAttribute('w-filter-radio-variable');
+      });
+      document.querySelectorAll('[wized][w-filter-select-variable]').forEach((el) => {
+        mapping[el.getAttribute('wized')] = el.getAttribute('w-filter-select-variable');
+      });
+      document
+        .querySelectorAll('[wized][w-filter-select-range-from-variable]')
+        .forEach((el) => {
+          mapping[el.getAttribute('wized')] = el.getAttribute('w-filter-select-range-from-variable');
+        });
+      document
+        .querySelectorAll('[wized][w-filter-select-range-to-variable]')
+        .forEach((el) => {
+          mapping[el.getAttribute('wized')] = el.getAttribute('w-filter-select-range-to-variable');
+        });
+      document.querySelectorAll('[wized][w-filter-sort-variable]').forEach((el) => {
+        mapping[el.getAttribute('wized')] = el.getAttribute('w-filter-sort-variable');
+      });
+      document.querySelectorAll('[wized][w-filter-search-variable]').forEach((el) => {
+        mapping[el.getAttribute('wized')] = el.getAttribute('w-filter-search-variable');
+      });
+      return mapping;
+    };
+
+    applyParamsToWized(Wized, buildMapping());
+
     // Initialize chips manager first since other managers depend on it
     new FilterChipsManager(Wized);
 

--- a/src/utils/url-sync.js
+++ b/src/utils/url-sync.js
@@ -1,0 +1,61 @@
+export function setParam(key, value) {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+  if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
+    params.delete(key);
+  } else {
+    const encoded = Array.isArray(value) ? value.join(',') : value;
+    params.set(key, encoded);
+  }
+  const newUrl = `${window.location.pathname}?${params.toString()}${window.location.hash}`;
+  if (window.history && window.history.replaceState) {
+    window.history.replaceState({}, '', newUrl);
+  } else {
+    window.location.search = params.toString();
+  }
+}
+
+export function getParam(key) {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  return params.get(key);
+}
+
+export function removeParam(key) {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+  params.delete(key);
+  const newUrl = `${window.location.pathname}?${params.toString()}${window.location.hash}`;
+  if (window.history && window.history.replaceState) {
+    window.history.replaceState({}, '', newUrl);
+  } else {
+    window.location.search = params.toString();
+  }
+}
+
+function parseValue(val) {
+  if (!val) return '';
+  const trimmed = val.trim();
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    try {
+      return [JSON.parse(trimmed)];
+    } catch (_e) {
+      return trimmed;
+    }
+  }
+  if (trimmed.includes(',')) {
+    return trimmed.split(',').filter((v) => v !== '');
+  }
+  return trimmed;
+}
+
+export function applyParamsToWized(Wized, mapping = {}) {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+  for (const [param, variable] of Object.entries(mapping)) {
+    if (params.has(param)) {
+      const raw = params.get(param);
+      Wized.data.v[variable] = parseValue(raw);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement URL sync utility
- track wized/variable mappings in filters and update query params
- read query params on init and populate Wized state
- document URL sync feature
- bump version to 1.0.20
- add unit tests for url sync

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481482f31c83228c79b60e6fea726b