### PR TITLE
Update docs for self-hosted build

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ To use **Wized Filter and Pagination**, include the CDN link in the `<head>` tag
 ></script>
 ```
 
+### Self-Hosted Build
+
+If you want to serve the script from your own domain (for example via
+**Cloudflare Pages**), build the library locally:
+
+```bash
+npm install
+npm run build
+```
+
+The build command creates `dist/index.min.js`. Upload the repository (or just
+the generated `dist` folder) to your static hosting and reference the file in
+your HTML:
+
+```html
+<script async type="module" src="/dist/index.min.js"></script>
+```
+
 <br><br>
 <br><br>
 <br><br>


### PR DESCRIPTION
## Summary
- add instructions for building `dist/index.min.js` for self-hosting

## Testing
- `npm test` *(fails: window.history.replaceState.mockClear is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68481824f7cc8322a86aba1114c87e14