### PR TITLE
Add emit polyfill and improve URL sync

### DIFF
--- a/src/__tests__/unit/URLSync.test.js
+++ b/src/__tests__/unit/URLSync.test.js
@@ -1,13 +1,25 @@
 /* global describe, test, expect, beforeEach */
 import { setParam, applyParamsToWized } from '../../utils/url-sync';
-import Wized from '../../__mocks__/wized';
 import FilterSearchManager from '../../filters/filter-search';
+
+let Wized;
 
 describe('URL Sync', () => {
   beforeEach(() => {
-    window.location.search = '';
-    window.history.replaceState.mockClear();
-    Wized.data.v = {};
+    window.location = { search: '', pathname: '/', hash: '' };
+    if (typeof window.history.replaceState?.mockClear === 'function') {
+      window.history.replaceState.mockClear();
+    } else {
+      window.history.replaceState = jest.fn((_, __, url) => {
+        const parsed = new URL(url, 'http://localhost');
+        window.location.search = parsed.search;
+      });
+    }
+    Wized = {
+      data: { v: {}, r: {}, subscribe: jest.fn() },
+      requests: { execute: jest.fn() },
+      on: jest.fn(),
+    };
   });
 
   test('changing search filter updates location search', async () => {
@@ -27,12 +39,16 @@ describe('URL Sync', () => {
     manager.setupSearch(input);
 
     await manager.updateWizedVariable(input, 'searchVar', 'page', 'req');
-    expect(window.location.search).toBe('?search=shoes');
+    expect(window.history.replaceState).toHaveBeenCalled();
+    const urlArg = window.history.replaceState.mock.calls[0][2];
+    expect(urlArg).toContain('?search=shoes');
   });
 
   test('applyParamsToWized populates variables from URL', () => {
-    window.location.search = '?search=boots';
-    applyParamsToWized(Wized, { search: 'searchVar' });
+    const originalWindow = global.window;
+    global.window = {};
+    applyParamsToWized(Wized, { search: 'searchVar' }, '?search=boots');
+    global.window = originalWindow;
     expect(Wized.data.v.searchVar).toBe('boots');
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,23 @@ export { FilterSearchManager };
 // Initialize components when loaded in browser
 if (typeof window !== 'undefined') {
   window.Wized = window.Wized || [];
+
+  // Polyfill for legacy libraries expecting `Wized.emit`
+  if (
+    typeof window.Wized.emit !== 'function' &&
+    window.Wized.requests &&
+    typeof window.Wized.requests.execute === 'function'
+  ) {
+    window.Wized.emit = (requestName, ...args) => {
+      if (args.length > 0) {
+        console.warn(
+          'Wized.emit provided with additional arguments which are ignored in V2'
+        );
+      }
+      return window.Wized.requests.execute(requestName);
+    };
+  }
+
   window.Wized.push((Wized) => {
     const buildMapping = () => {
       const mapping = {};

--- a/src/utils/url-sync.js
+++ b/src/utils/url-sync.js
@@ -49,9 +49,10 @@ function parseValue(val) {
   return trimmed;
 }
 
-export function applyParamsToWized(Wized, mapping = {}) {
-  if (typeof window === 'undefined') return;
-  const params = new URLSearchParams(window.location.search);
+export function applyParamsToWized(Wized, mapping = {}, searchOverride = null) {
+  if (typeof window === 'undefined' && !searchOverride) return;
+  const search = searchOverride ?? (window.location ? window.location.search : '');
+  const params = new URLSearchParams(search);
   for (const [param, variable] of Object.entries(mapping)) {
     if (params.has(param)) {
       const raw = params.get(param);


### PR DESCRIPTION
## Summary
- add fallback for `Wized.emit` so the library works with embed v2
- extend `applyParamsToWized` to accept custom search strings
- adjust URL sync tests for the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849259a8d108322b5193059d0936b5d