### PR TITLE
Add Supabase function memory config

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,2 @@
+[functions.fetch_jobs]
+memory = 512

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,5 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+};

--- a/supabase/functions/_shared/withCors.ts
+++ b/supabase/functions/_shared/withCors.ts
@@ -1,0 +1,24 @@
+import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
+import { corsHeaders } from "./cors.ts";
+
+export function serveWithCors(
+  handler: (req: Request) => Response | Promise<Response>,
+) {
+  serve(async (req: Request) => {
+    if (req.method === "OPTIONS") {
+      return new Response("ok", { headers: corsHeaders });
+    }
+
+    const resp = await handler(req);
+    const headers = new Headers(resp.headers);
+    for (const [k, v] of Object.entries(corsHeaders)) {
+      headers.set(k, v);
+    }
+
+    return new Response(resp.body, {
+      status: resp.status,
+      statusText: resp.statusText,
+      headers,
+    });
+  });
+}

--- a/supabase/functions/fetch_jobs/index.ts
+++ b/supabase/functions/fetch_jobs/index.ts
@@ -1,0 +1,17 @@
+import { serveWithCors } from "../_shared/withCors.ts";
+
+/**
+ * Example fetch_jobs function returning a static job list.
+ * Replace this with your database logic as needed.
+ */
+async function fetchJobsFromDb() {
+  // This is a placeholder for database logic
+  return [{ id: 1, title: "Example Job" }];
+}
+
+serveWithCors(async (_req) => {
+  const jobs = await fetchJobsFromDb();
+  return new Response(JSON.stringify(jobs), {
+    headers: { "Content-Type": "application/json" },
+  });
+});


### PR DESCRIPTION
## Summary
- configure `fetch_jobs` edge function to use 512 MB RAM
- wrap Edge Functions with a reusable CORS handler

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684af80cb6a483229a479a17a6297fd8