### PR TITLE
Add Yandex CDN deployment workflow

### DIFF
--- a/.github/workflows/yandex-cdn.yml
+++ b/.github/workflows/yandex-cdn.yml
@@ -1,0 +1,50 @@
+name: Upload to Yandex CDN
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+
+      - name: Clean install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: |
+          npm run clean
+          npm run build
+
+      - name: Install Yandex Cloud CLI
+        run: |
+          curl -sSL https://storage.yandexcloud.net/yandexcloud-yc/install.sh | bash -s -- -i $HOME/yandex-cloud
+          echo "$HOME/yandex-cloud/yandex-cloud/bin" >> $GITHUB_PATH
+
+      - name: Authenticate Yandex Cloud
+        run: |
+          echo '${{ secrets.YC_SERVICE_ACCOUNT }}' > key.json
+          yc config profile create github-actions --non-interactive
+          yc config set service-account-key key.json
+
+      - name: Upload dist to Object Storage
+        run: yc storage cp --recursive dist s3://${{ secrets.YC_BUCKET }}/
+
+      - name: Purge CDN cache (optional)
+        if: env.YC_CDN_RESOURCE_ID != ''
+        run: yc cdn cache purge --resource-id $YC_CDN_RESOURCE_ID --path '/'
+        env:
+          YC_CDN_RESOURCE_ID: ${{ secrets.YC_CDN_RESOURCE_ID }}
+

--- a/README.md
+++ b/README.md
@@ -510,3 +510,15 @@ For support, please:
 - **📖 Check the Documentation** – Refer to the official [documentation](https://github.com/aonnoy/wized-filter-pagination) for setup instructions and troubleshooting.
 - **🐞 Open an Issue** – If you encounter a bug or need assistance, submit an [issue](https://github.com/aonnoy/wized-filter-pagination/issues) on GitHub.
 - **📧 Contact Me** – You can reach me via email at [hello@aonnoysengupta.com](mailto:hello@aonnoysengupta.com) or connect with me on Discord (**aonnoy5683**).
+
+## GitHub Action: Yandex CDN Deployment
+
+This repository includes a workflow (`.github/workflows/yandex-cdn.yml`) that uploads the contents of the `dist` directory to a Yandex Object Storage bucket. The files can then be served via Yandex CDN.
+
+### Required Secrets
+
+- `YC_BUCKET` – name of the Object Storage bucket used as the CDN origin.
+- `YC_SERVICE_ACCOUNT` – JSON key for a service account with write access to the bucket.
+- `YC_CDN_RESOURCE_ID` – *(optional)* CDN resource ID used for cache purge after upload.
+
+The workflow triggers on pushes to the `main` branch or when a release tag is created. It installs the Yandex Cloud CLI, builds the project, synchronizes `dist/` with the specified bucket, and purges the CDN cache if a resource ID is provided.


### PR DESCRIPTION
## Summary
- add a new workflow to build and deploy `dist/` to Yandex Cloud CDN
- document workflow secrets in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4116d64c8322994ca740b489c9ba