### PR TITLE
Fix Yandex CLI path in CDN deploy workflow

### DIFF
--- a/.github/workflows/yandex-cdn.yml
+++ b/.github/workflows/yandex-cdn.yml
@@ -30,8 +30,9 @@ jobs:
 
       - name: Install Yandex Cloud CLI
         run: |
-          curl -sSL https://storage.yandexcloud.net/yandexcloud-yc/install.sh | bash -s -- -i $HOME/yandex-cloud
-          echo "$HOME/yandex-cloud/yandex-cloud/bin" >> $GITHUB_PATH
+          curl -sSL https://storage.yandexcloud.net/yandexcloud-yc/install.sh \
+            | bash -s -- -i $HOME/yandex-cloud -n
+          echo "$HOME/yandex-cloud/bin" >> $GITHUB_PATH
 
       - name: Authenticate Yandex Cloud
         run: |


### PR DESCRIPTION
## Summary
- ensure Yandex Cloud CLI installs to the right folder
- run installer in non-interactive mode

## Testing
- `npm test --silent`
- `npx jest --runInBand --color=false`

------
https://chatgpt.com/codex/tasks/task_e_684c4c1f69848322b8a7302282547c5f