### PR TITLE
Fix yc CLI non-interactive flag placement

### DIFF
--- a/.github/workflows/yandex-cdn.yml
+++ b/.github/workflows/yandex-cdn.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Authenticate Yandex Cloud
         run: |
           echo '${{ secrets.YC_SERVICE_ACCOUNT }}' > key.json
-          yc config profile create github-actions --non-interactive
+          yc --non-interactive config profile create github-actions
           yc config set service-account-key key.json
 
       - name: Upload dist to Object Storage


### PR DESCRIPTION
## Summary
- fix placement of `--non-interactive` flag in the Yandex CDN deployment workflow

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c600249d88322be5084db36cf8173