### PR TITLE
Fix Yandex Cloud auth command

### DIFF
--- a/.github/workflows/yandex-cdn.yml
+++ b/.github/workflows/yandex-cdn.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Authenticate Yandex Cloud
         run: |
           echo '${{ secrets.YC_SERVICE_ACCOUNT }}' > key.json
-          yc --non-interactive config profile create github-actions
+          yc config profile create github-actions
+          yc config profile activate github-actions
           yc config set service-account-key key.json
 
       - name: Upload dist to Object Storage


### PR DESCRIPTION
## Summary
- correct profile creation command in Yandex CDN workflow

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c60e9e8108322b3811269974f8c97