### PR TITLE
Fix Yandex CDN upload command

### DIFF
--- a/.github/workflows/yandex-cdn.yml
+++ b/.github/workflows/yandex-cdn.yml
@@ -42,7 +42,7 @@ jobs:
           yc config set service-account-key key.json
 
       - name: Upload dist to Object Storage
-        run: yc storage cp --recursive dist s3://${{ secrets.YC_BUCKET }}/
+        run: yc storage s3 cp --recursive dist s3://${{ secrets.YC_BUCKET }}/
 
       - name: Purge CDN cache (optional)
         if: env.YC_CDN_RESOURCE_ID != ''


### PR DESCRIPTION
## Summary
- upload dist to object storage using the `s3` subcommand

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c659d8bbc8322a6ee61652d7584d6