### PR TITLE
Fix Content-Type for Yandex CDN upload

### DIFF
--- a/.github/workflows/yandex-cdn.yml
+++ b/.github/workflows/yandex-cdn.yml
@@ -42,7 +42,17 @@ jobs:
           yc config set service-account-key key.json
 
       - name: Upload dist to Object Storage
-        run: yc storage s3 cp --recursive dist s3://${{ secrets.YC_BUCKET }}/
+        run: |
+          for file in dist/*; do
+            case "$file" in
+              *.js)
+                yc storage s3 cp "$file" s3://${{ secrets.YC_BUCKET }}/$(basename "$file") --content-type application/javascript
+                ;;
+              *)
+                yc storage s3 cp "$file" s3://${{ secrets.YC_BUCKET }}/
+                ;;
+            esac
+          done
 
       - name: Purge CDN cache (optional)
         if: env.YC_CDN_RESOURCE_ID != ''

--- a/README.md
+++ b/README.md
@@ -522,3 +522,7 @@ This repository includes a workflow (`.github/workflows/yandex-cdn.yml`) that up
 - `YC_CDN_RESOURCE_ID` – *(optional)* CDN resource ID used for cache purge after upload.
 
 The workflow triggers on pushes to the `main` branch or when a release tag is created. It installs the Yandex Cloud CLI, builds the project, synchronizes `dist/` with the specified bucket, and purges the CDN cache if a resource ID is provided.
+
+### Correct MIME Types
+
+Ensure JavaScript files are uploaded with `Content-Type: application/javascript` so browsers load them as ES modules. The workflow handles this automatically for `*.js` files.


### PR DESCRIPTION
## Summary
- ensure JS files are uploaded with the correct MIME type
- document MIME type requirement in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6a2e4f348322b940d1978e646582