### PR TITLE
Fix filter params restoration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,12 @@ if (typeof window !== 'undefined') {
       };
 
     applyParamsToWized(Wized, buildMapping());
+    // Re-apply URL parameters whenever new elements are injected after a request
+    if (typeof Wized.on === 'function') {
+      Wized.on('requestend', () => {
+        applyParamsToWized(Wized, buildMapping());
+      });
+    }
 
     // Initialize chips manager first since other managers depend on it
     new FilterChipsManager(Wized);


### PR DESCRIPTION
## Summary
- re-apply URL params after every request to support dynamic filters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d709446fc8322a6f53093871bd7d3