### PR TITLE
Fix Wized queue initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,17 +136,9 @@ if (typeof window !== 'undefined') {
     new FilterResetManager(Wized);
   };
 
-  const runInit = () => {
-    if (Array.isArray(window.Wized)) {
-      window.Wized.push(initLibrary);
-    } else {
-      initLibrary(window.Wized);
-    }
-  };
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', runInit);
+  if (Array.isArray(window.Wized)) {
+    window.Wized.push(initLibrary);
   } else {
-    runInit();
+    initLibrary(window.Wized);
   }
 }


### PR DESCRIPTION
## Summary
- push initialization to `window.Wized` immediately
- remove DOMContentLoaded guard so polyfills execute as soon as Wized loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684da7a2dd00832298dd0b470f1d3c90