### PR TITLE
Generate both minified and esm builds

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,20 +2,31 @@ import * as esbuild from 'esbuild';
 
 async function build() {
   try {
-    // Bundle and minify
-    const result = await esbuild.build({
+    const commonOptions = {
       entryPoints: ['src/index.js'],
       bundle: true,
-      minify: true,
       format: 'esm',
       target: ['es2020'],
-      outfile: 'dist/index.min.js',
-      sourcemap: false,
       platform: 'browser',
       define: {
         'process.env.NODE_ENV': '"production"',
       },
       pure: ['console.log', 'console.info', 'console.debug'],
+      sourcemap: false,
+    };
+
+    // Minified bundle for browsers
+    await esbuild.build({
+      ...commonOptions,
+      minify: true,
+      outfile: 'dist/index.min.js',
+    });
+
+    // ESM bundle for bundlers
+    await esbuild.build({
+      ...commonOptions,
+      minify: false,
+      outfile: 'dist/index.esm.js',
     });
 
     console.log('Build completed successfully!');


### PR DESCRIPTION
## Summary
- build both minified bundle and esm bundle

## Testing
- `npm test`
- `npm run build`
- `node -e "import('./dist/index.esm.js').then(m=>console.log(Object.keys(m)))"`
- `node -e "import('./dist/index.min.js').then(m=>console.log(Object.keys(m)))"`

------
https://chatgpt.com/codex/tasks/task_e_684daafcb16c8322ac567464348336d1