### PR TITLE
Fix URL params on first load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,9 +130,17 @@ if (typeof window !== 'undefined') {
     new FilterResetManager(Wized);
   };
 
+  const startLibrary = (WizedInstance) => {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => initLibrary(WizedInstance));
+    } else {
+      initLibrary(WizedInstance);
+    }
+  };
+
   if (Array.isArray(window.Wized)) {
-    window.Wized.push(initLibrary);
+    window.Wized.push(startLibrary);
   } else {
-    initLibrary(window.Wized);
+    startLibrary(window.Wized);
   }
 }


### PR DESCRIPTION
## Summary
- delay initialization until DOMContentLoaded

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db0e78dc88322ab86fcd869ff5ba4