### PR TITLE
Implement async Wized readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ To use **Wized Filter and Pagination**, include the CDN link in the `<head>` tag
 
 ### Wized Initialization
 
-Wait for Wized to load before running the library. If Wized is not loaded yet,
-it exposes an array that queues callbacks. Push a function to this array and it
-will execute once Wized is ready:
+The library automatically waits until Wized is fully loaded. If you need to
+run custom logic once Wized is ready, you can still push a callback to the
+`window.Wized` queue:
 
 ```html
 <script>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,8 @@ export default [
         require: true,
         process: true,
         setTimeout: true,
+        setInterval: true,
+        clearInterval: true,
         IntersectionObserver: true,
         URL: true,
         URLSearchParams: true,


### PR DESCRIPTION
## Summary
- automatically wait for Wized initialization before starting filters
- document automatic Wized initialization behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dbad7bc188322b9cde5651ead3409